### PR TITLE
Bump moment version to avoid audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jquery": "^3.1.1",
     "lodash": "^4.0.0",
     "loglevel": "^1.4.0",
-    "moment": "^2.11.2",
+    "moment": "^2.27.0",
     "node-schedule": "^1.0.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
The most recent version of loglevel-prefix-persist depends on moment@^2.11.2, which currently generates two npm audit warnings (https://www.npmjs.com/advisories/55 and https://www.npmjs.com/advisories/532). There should be no breaking changes in the moment API between 2.11.2 and the current version (2.27.0). Updating the dependency and pushing a new version to npm would resolve these warnings!

Note: the other dependency versions could also be bumped if desired, but I'm submitting this as a minimal patch that will resolve the audit warnings rather than a complete update.